### PR TITLE
Check proxy status for invalid json

### DIFF
--- a/app.js
+++ b/app.js
@@ -586,10 +586,19 @@ multiLinkSection.style.display = 'none';
 async function checkProxyStatusAndShowLinks() {
     try {
         const response = await fetch('/proxy-status');
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+            const text = await response.text();
+            console.error('Non-JSON response from /proxy-status:', text);
+            singleLinkSection.style.display = 'none';
+            multiLinkSection.style.display = 'none';
+            document.getElementById('applyStatus').innerText = 'Error: Unexpected response from server.';
+            return;
+        }
         const data = await response.json();
         // Find the selected country in the proxy list
         const selectedCountry = getSelectedCountry();
-        const activeProvider = data.providers.find(p => p.country === selectedCountry && p.active);
+        const activeProvider = data.providers && data.providers.find(p => p.country === selectedCountry && p.active);
         if (activeProvider) {
             // Proxy for selected country is active, show link input
             if (mode === 'single') {


### PR DESCRIPTION
Add robust error handling for non-JSON responses from `/proxy-status` to prevent parsing errors.

The previous code would throw an "Unexpected token '<'" error if the `/proxy-status` endpoint returned an HTML page (e.g., an error page from a proxy or server). This change checks the `Content-Type` header and handles non-JSON responses gracefully, displaying a user-friendly message and logging the full response for debugging.

---

[Open in Web](https://www.cursor.com/agents?id=bc-915caa63-2d0d-447e-943a-9054be854bea) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-915caa63-2d0d-447e-943a-9054be854bea)