### PR TITLE
Check proxy status for invalid json

### DIFF
--- a/routes/proxy.js
+++ b/routes/proxy.js
@@ -4,7 +4,8 @@ const { getProviderStatus } = require('../proxyPool');
 const logger = require('../logger');
 const fetch = require('node-fetch');
 
-router.get('/proxy-status', (req, res) => {
+// Change route from '/proxy-status' to '/'
+router.get('/', (req, res) => {
     try {
         // If you add query params in the future, use express-validator here for validation.
         const status = getProviderStatus();


### PR DESCRIPTION
Fix: Correct `/proxy-status` endpoint path.

Frontend was receiving HTML (e.g., 404 page) because the backend endpoint was effectively `/proxy-status/proxy-status` instead of the expected `/proxy-status`. This change aligns the backend route definition with how it's mounted.

---

[Open in Web](https://www.cursor.com/agents?id=bc-915caa63-2d0d-447e-943a-9054be854bea) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-915caa63-2d0d-447e-943a-9054be854bea)