### PR TITLE
Check proxy status for invalid json

### DIFF
--- a/routes/proxy.js
+++ b/routes/proxy.js
@@ -9,7 +9,7 @@ router.get('/', (req, res) => {
     try {
         // If you add query params in the future, use express-validator here for validation.
         const status = getProviderStatus();
-        res.json({ status, timestamp: new Date().toISOString() });
+        res.json({ providers: status, timestamp: new Date().toISOString() });
     } catch (err) {
         logger.error('Error in /proxy-status', err);
         res.status(500).json({ error: 'Proxy status error', details: err.message });


### PR DESCRIPTION
Rename 'status' key to 'providers' in proxy status API response to match frontend expectation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-915caa63-2d0d-447e-943a-9054be854bea) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-915caa63-2d0d-447e-943a-9054be854bea)